### PR TITLE
Remove unused parameterized dependency from install_requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 0.0.2
+  * Bump requests to 2.33.0 (CVE-2026-25645)
+
+## 0.0.1
+  * Previous release

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
         "requests==2.32.5",
         "backoff==2.2.1",
         "zeep==4.3.1",
-        "parameterized==0.9.0",
     ],
     entry_points="""
           [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="tap-workday",
-    version="0.0.1",
+    version="0.0.2",
     description="Singer.io tap for extracting data from workday API",
     author="Stitch",
     url="http://singer.io",
@@ -10,7 +10,7 @@ setup(
     py_modules=["tap_workday"],
     install_requires=[
         "singer-python==6.1.1",
-        "requests==2.32.5",
+        "requests==2.33.0",
         "backoff==2.2.1",
         "zeep==4.3.1",
     ],


### PR DESCRIPTION
## Summary

`parameterized` is not imported anywhere in this codebase and should not be included in the production image. Removing it from `install_requires`.